### PR TITLE
[Pr 04]/starter selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import LandingPage from "./views/LandingPage/LandingPage.jsx"
 import LogInPage from "./views/LogInPage/LogInPage.jsx"
 import SignUpPage from "./views/SignUpPage/SignUpPage.jsx"
+import StarterSelection from './views/StarterSelection/StarterSelection.jsx'
 import './App.css';
 
 function App() {
@@ -13,6 +14,7 @@ function App() {
               <Route path="/" element={<LandingPage />} />
               <Route path="/signup" element={<SignUpPage />} />
               <Route path="/login" element={<LogInPage />} />
+              <Route path='/starterselection' element={<StarterSelection />} />
             </Routes>
           </Router>
     </main>

--- a/src/views/LogInPage/LogInPage.jsx
+++ b/src/views/LogInPage/LogInPage.jsx
@@ -49,6 +49,7 @@ function LogInPage () {
           />
 
           <Button variant="contained"
+                  onClick={() => navigate('/starterselection')}
                   sx={{bgcolor:'#2C2C2C',
                       padding:'10px 110px',
                       borderRadius:'10px',

--- a/src/views/StarterSelection/StarterSelection.css
+++ b/src/views/StarterSelection/StarterSelection.css
@@ -1,0 +1,12 @@
+h2{
+  color:black;
+  margin:0;
+}
+
+.pokeball-sprite{
+  width: 225px;
+}
+
+.starter-sprites{
+  width:235px;
+}

--- a/src/views/StarterSelection/StarterSelection.jsx
+++ b/src/views/StarterSelection/StarterSelection.jsx
@@ -1,8 +1,70 @@
+import {Box, Button} from '@mui/material'
+import { useNavigate } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import './StarterSelection.css'
+
 function StarterSelection () {
+
+  const [showStarters, setShowStarters] = useState (false)
+  const [starters, setStarters] = useState ([])
+
+  function openPokeballs () {
+    setShowStarters(!showStarters)
+  }
+
+  useEffect(() => {
+    const fetchStarters = async () => {
+      const pokemon = ['bulbasaur', 'squirtle', 'charmander']
+      try {
+        const data = await Promise.all(
+          pokemon.map(p =>
+            fetch(`https://pokeapi.co/api/v2/pokemon/${p}`).then(res => res.json())
+          )
+        )
+
+        const sprites = data.map(p => ({
+          name: p.name,
+          img: p.sprites.front_default
+        }))
+
+        setStarters(sprites)
+      } catch (error) {
+        console.error('Error fetching starters:', error)
+      }
+    }
+
+    fetchStarters()
+  }, [])
+
+  const startersElements = starters.map((pokemon) => {
+    return(<Box sx={{display:'flex', flexDirection:'column', alignItems:'center'}}>
+            <h2>{pokemon.name.charAt(0).toUpperCase() + pokemon.name.slice(1)}</h2>
+            <img className="starter-sprites" src={pokemon.img} alt={pokemon.name} key={pokemon.name} />
+            <Button variant="contained">
+              Select
+            </Button>
+          </Box>)
+  })
+
   return (
-    <>
-    <h1>This is the starter selection page</h1>
-    </>
+    <Box sx={{display:'flex', flexDirection:'column', alignItems:'center'}}>
+      <h1>Which Pokemon is going to be your starter?</h1>
+      {showStarters ? <Box sx={{display:'flex'}}> {startersElements} </Box> : <Box>
+        <img className='pokeball-sprite' src="https://images.wikidexcdn.net/mwuploads/wikidex/6/6a/latest/20230115164405/Pok%C3%A9_Ball_EP.png" />
+        <img className='pokeball-sprite' src="https://images.wikidexcdn.net/mwuploads/wikidex/6/6a/latest/20230115164405/Pok%C3%A9_Ball_EP.png" />
+        <img className='pokeball-sprite' src="https://images.wikidexcdn.net/mwuploads/wikidex/6/6a/latest/20230115164405/Pok%C3%A9_Ball_EP.png" />
+      </Box>}
+      <Button variant='contained'
+              onClick={openPokeballs}
+              sx={{bgcolor:'#2C2C2C',
+                   padding:'10px 110px',
+                   borderRadius:'10px',
+                   fontSize:"0.73rem",
+                   marginTop:'35px'
+                  }}>
+        {showStarters ? 'Close Poke-balls' : 'Open Poke-balls'}
+      </Button>
+    </Box>
   )
 }
 

--- a/src/views/StarterSelection/StarterSelection.jsx
+++ b/src/views/StarterSelection/StarterSelection.jsx
@@ -1,0 +1,9 @@
+function StarterSelection () {
+  return (
+    <>
+    <h1>This is the starter selection page</h1>
+    </>
+  )
+}
+
+export default StarterSelection


### PR DESCRIPTION
## ✨ Summary of Changes

Created a Starter Selection page (/starter-selection) as a new route in the application.

Added a heading prompting the user to choose their starter Pokémon.

Implemented a button that toggles between showing three Pokéballs (closed) and the three starter Pokémon (Bulbasaur, Squirtle, Charmander) fetched from the PokéAPI.

Displayed each starter Pokémon with:

- A sprite (fetched dynamically from the API).

- A name (with the first letter capitalized).

- A Select button (future implementation: selecting a starter).

Styled the layout so that the three starters appear in a row when Pokéballs are opened.

Added conditional rendering logic:

Before opening → shows three closed Pokéballs.

After opening → shows the fetched starter Pokémon with their details.

Button toggles text between "Open Poké-balls" and "Close Poké-balls" for better user clarity.

## 🧪 How to Test

Navigate to /starter-selection.

Verify that you see the heading and three Pokéballs.

Click Open Poké-balls → three Pokémon (Bulbasaur, Squirtle, Charmander) should appear with their name, sprite, and a Select button.

Click Close Poké-balls → the Pokéballs should reappear, hiding the starters.

Confirm that sprites load properly from the PokéAPI (inspect network requests).

## ⚠️ Additional Notes

Selecting a Pokémon currently does not trigger any action (to be implemented in a future task).

Basic styling applied; animations (e.g., Pokéball opening effects) can be added later for a more engaging user experience.

## 📸 Screenshots (If Applicable)

[
<img width="1048" height="1027" alt="image" src="https://github.com/user-attachments/assets/b34c1a59-35c2-4c2f-ab93-af4fe658c663" />
/<img width="1048" height="1015" alt="image" src="https://github.com/user-attachments/assets/3b86b378-dc85-4434-9842-dc434f8b2369" />